### PR TITLE
Add getIndex() method to mt19937 engine

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -128,6 +128,7 @@
           return uses;
         };
         next.discard = function (count) {
+          uses += count;
           if ((index | 0) >= 624) {
             refreshData(data);
             index = 0;
@@ -137,7 +138,6 @@
             refreshData(data);
             index = 0;
           }
-          uses += count;
           index = (index + count) | 0;
           return next;
         };

--- a/lib/random.js
+++ b/lib/random.js
@@ -122,6 +122,12 @@
           index = (index + 1) | 0;
           return temper(value) | 0;
         }
+        next.getIndex = function() {
+          if ((index | 0) >= 624) {
+            return 0;
+          }
+          return index | 0;
+        };
         next.discard = function (count) {
           if ((index | 0) >= 624) {
             refreshData(data);

--- a/lib/random.js
+++ b/lib/random.js
@@ -111,6 +111,7 @@
       function mt19937() {
         var data = new Int32Array(624);
         var index = 0;
+        var uses = 0;
 
         function next() {
           if ((index | 0) >= 624) {
@@ -120,13 +121,11 @@
 
           var value = data[index];
           index = (index + 1) | 0;
+          uses += 1;
           return temper(value) | 0;
         }
-        next.getIndex = function() {
-          if ((index | 0) >= 624) {
-            return 0;
-          }
-          return index | 0;
+        next.getUseCount = function() {
+          return uses;
         };
         next.discard = function (count) {
           if ((index | 0) >= 624) {
@@ -138,6 +137,7 @@
             refreshData(data);
             index = 0;
           }
+          uses += count;
           index = (index + count) | 0;
           return next;
         };
@@ -149,6 +149,7 @@
             data[i] = previous = (imul((previous ^ (previous >>> 30)), 0x6c078965) + i) | 0;
           }
           index = 624;
+          uses = 0;
           return next;
         };
         next.seedWithArray = function (source) {

--- a/spec/engines.mt19937Spec.js
+++ b/spec/engines.mt19937Spec.js
@@ -28,16 +28,56 @@
       });
     });
 
-    describe("method: getIndex", function() {
-      it("returns the current index", function() {
+    describe("method: getUseCount", function() {
+      it("starts at zero", function() {
+        var mt = Random.engines.mt19937();
+        expect(mt.getUseCount()).toBe(0);
+
+        mt.seedWithArray([0x1234, 0x2345]);
+        expect(mt.getUseCount()).toBe(0);
+      });
+
+      it("increments with each generated random number", function() {
         var mt = Random.engines.mt19937();
         mt.seedWithArray([0x1234, 0x2345]);
 
-        for (var i = 0; i < 100; i++) {
-          expect(mt.getIndex()).toBe(i);
+        for (var i = 0; i < 1000; i++) {
+          expect(mt.getUseCount()).toBe(i);
           mt();
-          expect(mt.getIndex()).toBe(i+1);
+          expect(mt.getUseCount()).toBe(i+1);
         }
+      });
+
+      it("increments with each discarded random number", function() {
+        var mt = Random.engines.mt19937();
+        mt.seedWithArray([0x1234, 0x2345]);
+
+        for (var i = 0; i < 1000; i++) {
+          expect(mt.getUseCount()).toBe(i);
+          mt.discard(1);
+          expect(mt.getUseCount()).toBe(i+1);
+        }
+
+        mt.discard(25);
+        expect(mt.getUseCount()).toBe(1025);
+      });
+
+      it("can be used to resume from a previous chain with the same seed", function() {
+        var mt = Random.engines.mt19937();
+        mt.seedWithArray([0x1234, 0x2345]);
+
+        for (var i = 0; i < 1000; i++) {
+          mt();
+        }
+        var mtUseCount = mt.getUseCount();
+        expect(mtUseCount).toBe(1000);
+
+        var newMt = Random.engines.mt19937();
+        newMt.seedWithArray([0x1234, 0x2345]);
+
+        newMt.discard(mtUseCount);
+
+        expect(newMt()).toBe(mt());
       });
     });
 

--- a/spec/engines.mt19937Spec.js
+++ b/spec/engines.mt19937Spec.js
@@ -28,6 +28,19 @@
       });
     });
 
+    describe("method: getIndex", function() {
+      it("returns the current index", function() {
+        var mt = Random.engines.mt19937();
+        mt.seedWithArray([0x1234, 0x2345]);
+
+        for (var i = 0; i < 100; i++) {
+          expect(mt.getIndex()).toBe(i);
+          mt();
+          expect(mt.getIndex()).toBe(i+1);
+        }
+      });
+    });
+
     describe("method: autoSeed", function () {
       it("returns the same engine", function () {
         var mt = Random.engines.mt19937();

--- a/spec/engines.mt19937Spec.js
+++ b/spec/engines.mt19937Spec.js
@@ -52,14 +52,17 @@
         var mt = Random.engines.mt19937();
         mt.seedWithArray([0x1234, 0x2345]);
 
+        mt.discard(1000);
+        expect(mt.getUseCount()).toBe(1000);
+
         for (var i = 0; i < 1000; i++) {
-          expect(mt.getUseCount()).toBe(i);
+          expect(mt.getUseCount()).toBe(1000 + i);
           mt.discard(1);
-          expect(mt.getUseCount()).toBe(i+1);
+          expect(mt.getUseCount()).toBe(1001 + i);
         }
 
         mt.discard(25);
-        expect(mt.getUseCount()).toBe(1025);
+        expect(mt.getUseCount()).toBe(2025);
       });
 
       it("can be used to resume from a previous chain with the same seed", function() {


### PR DESCRIPTION
If you're using the mt19937 engine, you should now be able to do
the following:

    var mt = Random.engines.mt19937();

    // Use an already known seed
    mt.seedWithArray(seed);

    // use the generator some number of times...
    mt();
    mt();

    // figure out how many times you've used it (should return 2)
    mt.getIndex();

Then, you should be able to resume generating from the same exact
sequence where you left off...

    var mt = Random.engines.mt19937();

    // Use the same seed
    mt.seedWithArray(seed);

    // Skip back to where you were by discarding your previous
    // number of generated numbers (2 comes from the above example)
    mt.discard(2);

    // Get the next random number
    mt();

There's no comparable mechanism to do the same thing with the `nativeMath` or `browserCrypto`, and thus there's nothing to implement for these engines.