### PR TITLE
Fix generateEntropyArray() to not overwrite current time

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -178,11 +178,11 @@
 
   Random.generateEntropyArray = function () {
     var array = [];
-    array.push(new Date().getTime() | 0);
     var engine = Random.engines.nativeMath;
     for (var i = 0; i < 16; ++i) {
       array[i] = engine() | 0;
     }
+    array.push(new Date().getTime() | 0);
     return array;
   };
 

--- a/spec/RandomSpec.js
+++ b/spec/RandomSpec.js
@@ -49,11 +49,17 @@
       it("gets entropy from the current date", function () {
         var GLOBAL = typeof module !== "undefined" ? global : root;
         var realDate = GLOBAL.Date;
-        spyOn(GLOBAL, "Date").andReturn(new realDate());
+        var stubDate = {
+          getTime: function () {
+            return 0x12345678;
+          }
+        };
+        spyOn(GLOBAL, "Date").andReturn(stubDate);
 
-        Random.generateEntropyArray();
+        var actual = Random.generateEntropyArray();
 
         expect(GLOBAL.Date).toHaveBeenCalled();
+        expect(actual).toContain(stubDate.getTime());
         GLOBAL.Date = realDate;
       });
 


### PR DESCRIPTION
The latest version of `generateEntropyArray()` on `master` (at least as of `bc6f65b`) discards the current time from the entropy array.  The `for` loop that populates the entropy array with random data overwrites the current time value previously `push`ed to the array at element 0.  I don't believe that was the original intention.

This pull request simply moves the `push` after the `for` loop to ensure the entropy array contains the intended data.  The modified test fails without the proposed change and passes when it is applied.

Not sure if the modified test is the best realization of the intent of this PR.  Obviously, it's possible for the native Math engine to produce the value returned from the stubbed `getTime()` function.  But keeping the expectation that the stubbed `Date` constructor function was called should provide enough confidence that the current time is actually present in the entropy array.