### PR TITLE
Fix Int32Array detection on iOS 9 Safari

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -165,7 +165,7 @@
 
       return mt19937;
     }(typeof Int32Array === "function" ? Int32Array : Array)),
-    browserCrypto: (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function" && typeof Int32Array === "function") ? (function () {
+    browserCrypto: (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function" && (typeof Int32Array === "function" || typeof Int32Array === "object")) ? (function () {
       var data = null;
       var index = 128;
 


### PR DESCRIPTION
For one reason or another, the type of Int32Array is "object" rather than "function", making detection fail. By checking for both, it allows crypto.getRandomValues() to be used on iOS 9 Safari.

With the fix, this library is now perfect for UUID generation.
